### PR TITLE
Add deletion option for saved images and text

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,6 +127,27 @@ def get_images():
         return jsonify({'status': 'error', 'message': str(e)}), 500
 
 
+@app.route('/delete_image/<int:image_id>', methods=['DELETE'])
+def delete_image(image_id):
+    """Delete an image and its associated text by id."""
+    try:
+        conn = get_db_connection()
+        cur = conn.cursor()
+        cur.execute(
+            "DELETE FROM generated_images WHERE id = %s", (image_id,)
+        )
+        deleted = cur.rowcount
+        conn.commit()
+        cur.close()
+        conn.close()
+        if deleted:
+            return jsonify({'status': 'ok'})
+        else:
+            return jsonify({'status': 'error', 'message': 'Image not found'}), 404
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
 @app.route('/history.html')
 def serve_history():
     return send_from_directory('.', 'history.html')

--- a/history.html
+++ b/history.html
@@ -66,6 +66,20 @@
             word-break: break-word;
         }
 
+        .delete-btn {
+            margin-top: 10px;
+            background-color: #ff4d4d;
+            color: #fff;
+            border: none;
+            padding: 5px 10px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+
+        .delete-btn:hover {
+            background-color: #ff0000;
+        }
+
     </style>
 </head>
 
@@ -96,6 +110,23 @@
                     p.className = 'prompt-text';
                     p.textContent = item.prompt_text || '(No prompt text)';
                     itemDiv.appendChild(p);
+
+                    const delBtn = document.createElement('button');
+                    delBtn.className = 'delete-btn';
+                    delBtn.textContent = 'Delete';
+                    delBtn.addEventListener('click', () => {
+                        fetch(`/delete_image/${item.id}`, { method: 'DELETE' })
+                            .then(res => res.json())
+                            .then(result => {
+                                if (result.status === 'ok') {
+                                    itemDiv.remove();
+                                } else {
+                                    console.error('Delete failed:', result.message);
+                                }
+                            })
+                            .catch(err => console.error('Error deleting image:', err));
+                    });
+                    itemDiv.appendChild(delBtn);
 
                     container.appendChild(itemDiv);
                 });


### PR DESCRIPTION
## Summary
- enable deletion of stored images and prompts via new `/delete_image/<id>` endpoint
- add delete button to history page with styling and client-side fetch

## Testing
- `python -m py_compile app.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_68be8777a7e0832a88d28c176ad9bbce