### PR TITLE
Allow multilingual keyboard input for name field

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,7 +202,7 @@ canvas#cap{display:none}
   <div class="panel">
     <h3 id="title">ENTER PHOTO NAME</h3>
     <label for="name">File name</label>
-    <input id="name" type="text" placeholder="e.g. midnight-orb" inputmode="latin"/>
+    <input id="name" type="text" placeholder="e.g. midnight-orb" inputmode="text"/>
     <div class="actions">
       <button class="btn" id="cancel">Cancel</button>
       <button class="btn primary" id="confirm">Confirm</button>


### PR DESCRIPTION
## Summary
- use generic text input mode on the photo name field to support non-Latin keyboards

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be9473e2d0832aa9a7c52d3a16d4b3