### PR TITLE
Open name input synchronously

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,9 +305,8 @@ shutter.addEventListener('click', ()=>{
   ctx.fillStyle=g; ctx.fillRect(0,0,w,h); ctx.globalCompositeOperation='source-over';
 
   flashAnimation();
-  cap.toBlob(b=>{
-    lastBlob=b; modal.classList.add('open'); nameInput.value=''; setTimeout(()=>nameInput.focus(),60);
-  },'image/png',.95);
+  cap.toBlob(b=>{ lastBlob=b; },'image/png',.95);
+  modal.classList.add('open'); nameInput.value=''; nameInput.focus();
 });
 
 btnConfirm.addEventListener('click', async ()=>{


### PR DESCRIPTION
## Summary
- Focus the name input synchronously when capturing a photo to ensure mobile keyboards appear

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be9770f05c832a9a84474cc35945f7