### PR TITLE
Redesign camera interface with neon controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,224 +1,356 @@
-
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang="zh-Hant">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Speculative Camera</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      height: 100%;
-      font-family: Arial, sans-serif;
-      background: #000;
-      color: #fff;
-    }
-    .camera-view {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-    }
-    header {
-      position: absolute;
-      top: 0;
-      width: 100%;
-      padding: 10px 0;
-      text-align: center;
-      background: rgba(0,0,0,0.3);
-      z-index: 2;
-    }
-    header h1 {
-      margin: 0;
-      font-size: 20px;
-    }
-    header a {
-      position: absolute;
-      left: 10px;
-      top: 10px;
-      color: #fff;
-      text-decoration: none;
-      font-size: 14px;
-    }
-    #video {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-    }
-    #canvas {
-      display: none;
-    }
-    .shutter {
-      position: absolute;
-      bottom: 30px;
-      left: 50%;
-      transform: translateX(-50%);
-      width: 70px;
-      height: 70px;
-      border-radius: 50%;
-      background: rgba(255,255,255,0.4);
-      border: 4px solid #fff;
-      cursor: pointer;
-      z-index: 2;
-    }
-    #loading {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(255,255,255,0.5);
-      color: #000;
-      display: none;
-      justify-content: center;
-      align-items: center;
-      z-index: 4;
-    }
-    .modal {
-      display: none;
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0,0,0,0.7);
-      justify-content: center;
-      align-items: center;
-      z-index: 3;
-    }
-    .modal-content {
-      background: #fff;
-      color: #000;
-      padding: 20px;
-      border-radius: 8px;
-      width: 90%;
-      max-width: 320px;
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-    }
-    .modal textarea {
-      width: 100%;
-      height: 80px;
-      font-size: 16px;
-    }
-    .modal button {
-      padding: 10px;
-      font-size: 16px;
-      background: #007BFF;
-      color: #fff;
-      border: none;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-  </style>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"/>
+<title>Speculative Camera</title>
+<style>
+:root{
+  --fg: rgba(255,255,255,.92);
+  --muted: rgba(255,255,255,.65);
+  --neon1:#4fd1ff; --neon2:#9b59ff; --neon3:#3dff9f;
+  --shutter: clamp(64px, 15vw, 88px);
+}
+*{box-sizing:border-box} html,body{height:100%}
+body{
+  margin:0; color:var(--fg);
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue","PingFang TC","Noto Sans TC",sans-serif;
+  background:
+    radial-gradient(1000px 700px at 70% 8%, #1a1f3a 0%, transparent 60%),
+    radial-gradient(900px 900px at 20% 92%, #082a2a 0%, transparent 55%),
+    linear-gradient(135deg,#0d1226 0%,#090b18 100%);
+  overflow:hidden;
+}
+.haze{position:fixed; inset:-20% -20% -20% -20%; pointer-events:none; filter:blur(60px) saturate(130%);
+  background:
+    radial-gradient(50% 50% at 20% 30%, rgba(79,209,255,.35), transparent 60%),
+    radial-gradient(40% 60% at 80% 20%, rgba(155,89,255,.35), transparent 65%),
+    radial-gradient(60% 40% at 30% 85%, rgba(61,255,159,.35), transparent 60%);
+  mix-blend-mode:screen; animation:drift 14s ease-in-out infinite alternate; opacity:.85;}
+@keyframes drift{0%{transform:translate3d(-2%,-1%,0)}100%{transform:translate3d(2%,1%,0)}}
+
+.app{position:relative; height:100dvh; width:100%; display:flex; flex-direction:column;}
+
+.topbar{
+  position:absolute; top:0; left:0; right:0; z-index:10;
+  display:flex; justify-content:space-between; gap:12px;
+  padding: env(safe-area-inset-top) 14px 10px 14px; opacity:.95;
+}
+.badge{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:8px 12px; border-radius:14px;
+  background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02));
+  border:1px solid rgba(255,255,255,.14); font-size:12px; color:var(--muted);
+  backdrop-filter: blur(6px) saturate(120%);
+}
+.icon{width:18px;height:18px; display:inline-block}
+.icon.grid{
+  background: conic-gradient(from 0deg, var(--neon3), var(--neon1));
+  -webkit-mask: linear-gradient(#000 0 0) center/100% 2px repeat,
+                 linear-gradient(90deg,#000 0 0) center/2px 100% repeat;
+          mask: linear-gradient(#000 0 0) center/100% 2px repeat,
+                 linear-gradient(90deg,#000 0 0) center/2px 100% repeat;
+  clip-path: inset(20% 20% 20% 20%); opacity:.9;
+}
+
+.view{
+  position:relative; flex:1; overflow:hidden; border-radius:24px; margin:12px;
+  background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.01));
+  border:1px solid rgba(255,255,255,.08);
+  box-shadow:
+    0 0 0 1px rgba(255,255,255,.04) inset,
+    0 30px 120px rgba(79,209,255,.07),
+    0 60px 160px rgba(155,89,255,.06),
+    0 80px 180px rgba(61,255,159,.05);
+  backdrop-filter: blur(4px) saturate(120%);
+}
+video{position:absolute; inset:0; width:100%; height:100%; object-fit:cover;
+  transform-origin:center; transform:scale(var(--zoom,1)); transition:transform .12s ease;}
+.grid{
+  position:absolute; inset:0; pointer-events:none; opacity:.35; display:none;
+  background:
+    linear-gradient(#fff4 0 0) 33.33% 0/1px 100% no-repeat,
+    linear-gradient(90deg,#fff4 0 0) 0 33.33%/100% 1px no-repeat,
+    linear-gradient(#fff4 0 0) 66.66% 0/1px 100% no-repeat,
+    linear-gradient(90deg,#fff4 0 0) 0 66.66%/100% 1px no-repeat;
+  mix-blend-mode:screen;
+}
+.grid.show{display:block}
+.flashFX{position:absolute; inset:0; background:#fff; opacity:0; pointer-events:none}
+
+.bottom{
+  position:absolute; left:0; right:0; bottom:0; z-index:11;
+  padding: 10px 18px calc(12px + env(safe-area-inset-bottom));
+  /* 半透明遮罩（非全螢幕取景） */
+  background: linear-gradient(180deg, rgba(12,14,30,.72), rgba(8,10,22,.86));
+  border-top: 1px solid rgba(255,255,255,.12);
+  backdrop-filter: blur(10px) saturate(120%);
+  box-shadow: 0 -20px 80px rgba(79,209,255,.12), 0 -40px 120px rgba(155,89,255,.10);
+}
+
+.zoomRow{
+  display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:12px; margin-bottom:10px;
+  color:var(--muted); font-size:12px; letter-spacing:.06em;
+}
+.zbtn{
+  width:36px; height:36px; display:grid; place-items:center; border-radius:10px; border:1px solid rgba(255,255,255,.14);
+  background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02)); color:var(--fg);
+}
+#zoomVal{min-width:48px; text-align:right; font-variant-numeric:tabular-nums; color:var(--fg)}
+
+.range{ -webkit-appearance:none; width:100%; height:36px; background:transparent; }
+.range:focus{outline:none}
+.range::-webkit-slider-runnable-track{ height:4px; border-radius:999px;
+  background:linear-gradient(90deg, var(--neon1), var(--neon2), var(--neon3));
+  box-shadow:0 0 16px rgba(155,89,255,.30)}
+.range::-webkit-slider-thumb{ -webkit-appearance:none; width:22px; height:22px; margin-top:-9px; border-radius:50%;
+  background: #fff; border:2px solid transparent;
+  background: linear-gradient(#0000,#0000) padding-box,
+              conic-gradient(from 0deg, var(--neon1), var(--neon2), var(--neon3), var(--neon1)) border-box;
+  box-shadow:0 0 14px rgba(79,209,255,.45)}
+.range::-moz-range-track{ height:4px; border-radius:999px; background:linear-gradient(90deg, var(--neon1), var(--neon2), var(--neon3));}
+.range::-moz-range-thumb{ width:22px; height:22px; border-radius:50%; border:0; background:#fff; box-shadow:0 0 14px rgba(79,209,255,.45)}
+
+.controls{
+  display:grid; grid-template-columns: 56px 1fr 56px; align-items:center; gap:18px; justify-items:center;
+}
+.spacer{width:56px; height:56px}
+
+.shutter{
+  position:relative; width:var(--shutter); height:var(--shutter); border-radius:50%;
+  border:none; outline:none; cursor:pointer; -webkit-tap-highlight-color:transparent;
+  background: radial-gradient(60% 60% at 50% 45%, rgba(0,0,0,.35), rgba(0,0,0,.6));
+  box-shadow:
+    0 0 0 2px rgba(255,255,255,.06) inset,
+    0 0 32px 8px rgba(79,209,255,.18),
+    0 0 56px 16px rgba(155,89,255,.14),
+    0 0 76px 26px rgba(61,255,159,.12);
+}
+.shutter:before{
+  content:""; position:absolute; inset:10%; border-radius:50%;
+  background:
+    linear-gradient(#0000,#0000) padding-box,
+    conic-gradient(from 0deg, var(--neon1), var(--neon2), var(--neon3), var(--neon1)) border-box;
+  border:2px solid transparent;
+}
+.flip{
+  justify-self:end; width:56px; height:56px; border-radius:12px; border:1px solid rgba(255,255,255,.16);
+  background:linear-gradient(135deg, rgba(79,209,255,.20), rgba(155,89,255,.15), rgba(61,255,159,.15));
+  display:grid; place-items:center; color:#fff; font-weight:700; letter-spacing:.06em;
+  box-shadow:0 8px 30px rgba(0,0,0,.25);
+}
+.flip::before{content:"⇄"; filter:drop-shadow(0 0 8px rgba(155,89,255,.6))}
+.helper{margin-top:6px; text-align:center; font-size:12px; color:var(--muted)}
+.modal{position:fixed; inset:0; display:none; place-items:center; z-index:50;
+  background: radial-gradient(100% 100% at 50% 50%, rgba(12,14,30,.6), rgba(6,7,14,.75));
+  backdrop-filter: blur(6px) saturate(120%);}
+.modal.open{display:grid}
+.panel{
+  width:min(92vw,520px); background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.03));
+  border:1px solid rgba(255,255,255,.12); border-radius:24px;
+  box-shadow:0 30px 100px rgba(79,209,255,.25),0 60px 140px rgba(155,89,255,.18),0 80px 160px rgba(61,255,159,.16);
+  padding:22px 18px 16px; position:relative;}
+.panel:before{content:""; position:absolute; inset:-2px; border-radius:inherit; padding:2px;
+  background:linear-gradient(135deg, rgba(79,209,255,.55), rgba(155,89,255,.45), rgba(61,255,159,.45));
+  -webkit-mask:linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+  -webkit-mask-composite:xor; mask-composite:exclude; opacity:.4; filter:blur(6px)}
+h3{margin:0 0 12px; font-weight:700; letter-spacing:.1em; font-size:clamp(16px,4.5vw,22px);
+  text-shadow:0 0 14px rgba(155,89,255,.55)}
+label{display:block; font-size:12px; color:var(--muted); margin-bottom:8px}
+input[type="text"]{width:100%; padding:14px; border-radius:14px; border:1px solid rgba(255,255,255,.14);
+  background:rgba(6,10,24,.45); color:var(--fg); font-size:16px; outline:none}
+.actions{display:flex; gap:12px; margin-top:14px}
+.btn{flex:1; padding:14px 16px; border-radius:14px; border:1px solid rgba(255,255,255,.14);
+  background:linear-gradient(180deg, rgba(255,255,255,.08), rgba(255,255,255,.02));
+  color:var(--fg); font-weight:700; letter-spacing:.06em; text-align:center; cursor:pointer}
+.btn.primary{background:linear-gradient(135deg, rgba(79,209,255,.35), rgba(155,89,255,.35), rgba(61,255,159,.35))}
+canvas#cap{display:none}
+
+.loading{position:fixed; inset:0; background:rgba(255,255,255,0.5); color:#000; display:none; z-index:99; align-items:center; justify-content:center;}
+</style>
 </head>
 <body>
-  <div class="camera-view">
-    <header>
-      <a href="/history.html">History</a>
-      <h1>Speculative Camera</h1>
-    </header>
-    <video id="video" autoplay playsinline></video>
-    <canvas id="canvas"></canvas>
-    <div id="loading"><p>Saving... Please wait</p></div>
-    <div class="shutter" id="shutter"></div>
+<div class="haze" aria-hidden="true"></div>
+<div id="loading" class="loading"><p>Saving... Please wait</p></div>
+<div class="app">
+  <div class="topbar">
+    <button id="gridBtn" class="badge"><i class="icon grid" aria-hidden="true"></i><span>Grid</span></button>
   </div>
 
-  <div id="prompt-modal" class="modal">
-    <div class="modal-content">
-      <textarea id="prompt-input" placeholder="Enter text"></textarea>
+  <div class="view" aria-label="viewfinder">
+    <video id="video" playsinline autoplay muted></video>
+    <div id="grid" class="grid"></div>
+    <div id="flashFX" class="flashFX"></div>
+  </div>
 
-      <button id="prompt-save">Save</button>
+  <div class="bottom">
+    <div class="zoomRow">
+      <button class="zbtn" id="zoomMinus" aria-label="Zoom out">−</button>
+      <input id="zoomRange" class="range" type="range" min="1" max="4" step="0.01" value="1" aria-label="Zoom"/>
+      <div id="zoomVal">1.00×</div>
+    </div>
+    <div class="controls">
+      <div class="spacer" aria-hidden="true"></div>
+      <button class="shutter" id="shutter" aria-label="Take photo"></button>
+      <button class="flip" id="flip" aria-label="Switch camera"></button>
+    </div>
+    <div class="helper">拖曳上方滑桿縮放　•　右側切換前／後鏡頭</div>
+  </div>
+</div>
+
+<div class="modal" id="modal" role="dialog" aria-modal="true" aria-labelledby="title">
+  <div class="panel">
+    <h3 id="title">ENTER PHOTO NAME</h3>
+    <label for="name">File name</label>
+    <input id="name" type="text" placeholder="e.g. midnight-orb" inputmode="latin"/>
+    <div class="actions">
+      <button class="btn" id="cancel">Cancel</button>
+      <button class="btn primary" id="confirm">Confirm</button>
     </div>
   </div>
+</div>
 
-  <script>
-    const video = document.getElementById('video');
-    const canvas = document.getElementById('canvas');
-    const shutter = document.getElementById('shutter');
-    const loadingDiv = document.getElementById('loading');
-    const promptModal = document.getElementById('prompt-modal');
-    const promptInput = document.getElementById('prompt-input');
-    const promptSave = document.getElementById('prompt-save');
-    let stream = null;
-    let capturedBlob = null;
+<canvas id="cap"></canvas>
 
-    async function startCamera() {
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: 'environment' },
-          audio: false
-        });
-        video.srcObject = stream;
-        await video.play();
-      } catch (err) {
-        console.error('Error accessing camera:', err);
-        alert('Unable to access the camera. Please check permissions and try again.');
+<script>
+let facing='environment', stream, capturedBlob, track, supportsZoom=false;
+const video=document.getElementById('video');
+const grid=document.getElementById('grid');
+const flashFX=document.getElementById('flashFX');
+const shutter=document.getElementById('shutter');
+const flip=document.getElementById('flip');
+const gridBtn=document.getElementById('gridBtn');
+const cap=document.getElementById('cap');
+const modal=document.getElementById('modal');
+const nameInput=document.getElementById('name');
+const btnConfirm=document.getElementById('confirm');
+const btnCancel=document.getElementById('cancel');
+const loadingDiv=document.getElementById('loading');
+
+const zoomRange=document.getElementById('zoomRange');
+const zoomVal=document.getElementById('zoomVal');
+const zoomMinus=document.getElementById('zoomMinus');
+
+gridBtn.addEventListener('click', ()=> grid.classList.toggle('show'));
+
+async function startCamera(){
+  try{
+    if(stream) stream.getTracks().forEach(t=>t.stop());
+    stream = await navigator.mediaDevices.getUserMedia({
+      video:{ facingMode:{ exact:facing } }
+    }).catch(()=> navigator.mediaDevices.getUserMedia({ video:{ facingMode:{ ideal:facing } }}));
+    video.srcObject = stream;
+    track = stream.getVideoTracks()[0];
+
+    supportsZoom = false;
+    zoomRange.min=1; zoomRange.max=4; zoomRange.step=0.01; zoomRange.value=1; setZoomDisplay(1);
+    try{
+      const caps = track.getCapabilities?.() || {};
+      if (caps.zoom){
+        supportsZoom = true;
+        zoomRange.min = caps.zoom.min ?? 1;
+        zoomRange.max = caps.zoom.max ?? 4;
+        zoomRange.step = caps.zoom.step || 0.1;
+        zoomRange.value = Math.max(zoomRange.min, 1);
+        await track.applyConstraints({advanced:[{zoom: Number(zoomRange.value)}]});
+        setZoomDisplay(zoomRange.value);
+      } else {
+        document.documentElement.style.setProperty('--zoom','1');
       }
+    }catch(e){ /* ignore */ }
+
+  }catch(e){ console.warn('getUserMedia failed:', e); }
+}
+startCamera();
+
+function setZoomDisplay(v){
+  zoomVal.textContent = `${Number(v).toFixed(2)}×`;
+}
+
+async function applyZoom(v){
+  if (supportsZoom && track){
+    try{ await track.applyConstraints({advanced:[{zoom:Number(v)}]}); }
+    catch(e){ /* 某些瀏覽器可能失敗，退回數位縮放 */ }
+  } else {
+    document.documentElement.style.setProperty('--zoom', v);
+  }
+  setZoomDisplay(v);
+}
+
+zoomRange.addEventListener('input', e=> applyZoom(e.target.value));
+zoomMinus.addEventListener('click', ()=>{
+  const step = Number(zoomRange.step) || 0.1;
+  zoomRange.value = Math.max(Number(zoomRange.min), Number(zoomRange.value)-step);
+  applyZoom(zoomRange.value);
+});
+zoomVal.addEventListener('click', ()=>{ zoomRange.value=1; applyZoom(1); });
+
+flip.addEventListener('click', ()=>{ facing = (facing==='environment')?'user':'environment'; startCamera(); });
+
+function flashAnimation(){
+  flashFX.style.transition='none'; flashFX.style.opacity='0.9';
+  requestAnimationFrame(()=>{ flashFX.style.transition='opacity 220ms ease'; flashFX.style.opacity='0'; });
+}
+
+shutter.addEventListener('click', ()=>{
+  if (!video.videoWidth) return;
+  const w=video.videoWidth, h=video.videoHeight;
+  cap.width=w; cap.height=h;
+  const ctx=cap.getContext('2d');
+  ctx.drawImage(video,0,0,w,h);
+  ctx.globalCompositeOperation='screen';
+  const g=ctx.createRadialGradient(w*.65,h*.35,10,w*.65,h*.35,Math.max(w,h)*.7);
+  g.addColorStop(0,'rgba(155,89,255,.20)'); g.addColorStop(1,'rgba(0,0,0,0)');
+  ctx.fillStyle=g; ctx.fillRect(0,0,w,h); ctx.globalCompositeOperation='source-over';
+
+  flashAnimation();
+  cap.toBlob(b=>{
+    capturedBlob=b; modal.classList.add('open'); nameInput.value=''; setTimeout(()=>nameInput.focus(),60);
+  },'image/png',.95);
+});
+
+btnConfirm.addEventListener('click', ()=>{
+  const name=(nameInput.value||'photo').replace(/[^\w\-]+/g,'_');
+  if(capturedBlob){
+    const a=document.createElement('a');
+    a.href=URL.createObjectURL(capturedBlob); a.download=`${name}.png`;
+    document.body.appendChild(a); a.click(); URL.revokeObjectURL(a.href); a.remove();
+    saveCapturedImage(name);
+  }
+  modal.classList.remove('open');
+});
+btnCancel.addEventListener('click', ()=> modal.classList.remove('open'));
+modal.addEventListener('click', e=>{ if(e.target===modal) modal.classList.remove('open'); });
+
+async function saveCapturedImage(userPrompt){
+  if(!capturedBlob){return;}
+  loadingDiv.style.display='flex';
+  try{
+    const saveFormData = new FormData();
+    saveFormData.append('original_image', capturedBlob, 'original.png');
+    saveFormData.append('prompt', userPrompt);
+    const saveResponse = await fetch('/save_image', {
+      method:'POST',
+      body: saveFormData
+    });
+    const saveResult = await saveResponse.json();
+    if(!saveResponse.ok){
+      throw new Error(saveResult.message || 'Unknown error saving image');
     }
+    console.log('Image saved with ID:', saveResult.id);
+  }catch(err){
+    console.error('Error saving image:', err);
+    alert(`Error: ${err.message}`);
+  }finally{
+    loadingDiv.style.display='none';
+    capturedBlob=null;
+  }
+}
 
-    shutter.addEventListener('click', async () => {
-      if (!stream) {
-        await startCamera();
-      }
-      const context = canvas.getContext('2d');
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      context.drawImage(video, 0, 0, canvas.width, canvas.height);
-      const imageData = canvas.toDataURL('image/jpeg');
-      capturedBlob = await (await fetch(imageData)).blob();
-      promptInput.value = '';
-      promptModal.style.display = 'flex';
-      promptInput.focus();
-    });
-
-    promptSave.addEventListener('click', async () => {
-      const userPrompt = promptInput.value.trim();
-      promptModal.style.display = 'none';
-      await saveCapturedImage(userPrompt);
-    });
-
-    promptInput.addEventListener('keydown', async (e) => {
-      if (e.key === 'Enter') {
-        e.preventDefault();
-        promptModal.style.display = 'none';
-        await saveCapturedImage(promptInput.value.trim());
-      }
-    });
-
-    async function saveCapturedImage(userPrompt) {
-      if (!capturedBlob) {
-        return;
-      }
-      loadingDiv.style.display = 'flex';
-      try {
-        const saveFormData = new FormData();
-        saveFormData.append('original_image', capturedBlob, 'original.jpg');
-        saveFormData.append('prompt', userPrompt);
-        const saveResponse = await fetch('/save_image', {
-          method: 'POST',
-          body: saveFormData
-        });
-        const saveResult = await saveResponse.json();
-        if (!saveResponse.ok) {
-          throw new Error(saveResult.message || 'Unknown error saving image');
-        }
-        console.log('Image saved with ID:', saveResult.id);
-      } catch (err) {
-        console.error('Error saving image:', err);
-        alert(`Error: ${err.message}`);
-      } finally {
-        loadingDiv.style.display = 'none';
-        capturedBlob = null;
-      }
-    }
-
-    document.addEventListener('DOMContentLoaded', () => {
-      startCamera();
-    });
-  </script>
-
+document.addEventListener('visibilitychange', ()=>{
+  if(!stream) return;
+  stream.getVideoTracks().forEach(t => t.enabled = !document.hidden);
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace basic camera page with neon-styled layout, grid toggle, zoom slider and camera flip controls
- Add naming modal that downloads the image and posts to `/save_image` via existing `saveCapturedImage`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68bfea5fa9f4832a9ad70f7fa8160e0c