### PR TITLE
Use async save captured image in confirm handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,13 +309,10 @@ shutter.addEventListener('click', ()=>{
   },'image/png',.95);
 });
 
-btnConfirm.addEventListener('click', ()=>{
+btnConfirm.addEventListener('click', async () => {
   const name=(nameInput.value||'photo').replace(/[^\w\-]+/g,'_');
   if(capturedBlob){
-    const a=document.createElement('a');
-    a.href=URL.createObjectURL(capturedBlob); a.download=`${name}.png`;
-    document.body.appendChild(a); a.click(); URL.revokeObjectURL(a.href); a.remove();
-    saveCapturedImage(name);
+    await saveCapturedImage(name);
   }
   modal.classList.remove('open');
 });


### PR DESCRIPTION
## Summary
- Simplify `btnConfirm` handler by removing temporary download anchor
- Await `saveCapturedImage` before closing modal

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c13069848c832a948e537376cd117e