### PR TITLE
Allow raw prompt text when saving images

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,9 @@ shutter.addEventListener('click', ()=>{
 });
 
 btnConfirm.addEventListener('click', async () => {
-  const name=(nameInput.value||'photo').replace(/[^\w\-]+/g,'_');
-  if(capturedBlob){
-    await saveCapturedImage(name);
+  const userPrompt = nameInput.value.trim() || 'photo';
+  if (capturedBlob) {
+    await saveCapturedImage(userPrompt);
   }
   modal.classList.remove('open');
 });


### PR DESCRIPTION
## Summary
- Capture user input directly for prompts without filename sanitization
- Continue appending raw prompt text to `/save_image`

## Testing
- `python -m py_compile app.py`
- ⚠️ `python app.py` (fails: could not translate host name "dpg-cttejurqf0us73erd8s0-a" to address)

------
https://chatgpt.com/codex/tasks/task_e_68c13500eda4832abc59e16f41d3941d