### PR TITLE
Use pywebpush 1.9.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 gunicorn
 flask==3.1.0
 psycopg2==2.9.10
-pywebpush==1.9.5
+pywebpush==1.9.4
 six==1.16.0
 six==1.16.0


### PR DESCRIPTION
## Summary
- depend on pywebpush 1.9.4 instead of missing 1.9.5 release

## Testing
- `pip install pywebpush==1.9.4` *(fails: Could not find a version that satisfies the requirement pywebpush==1.9.4)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c822dba9f4832a841b3b0d938b92a6