### PR TITLE
Improve broadcast send handler with async flow

### DIFF
--- a/history.html
+++ b/history.html
@@ -207,15 +207,24 @@
             })
             .catch(err => console.error('Error fetching images:', err));
 
-        document.getElementById('bc-send').addEventListener('click', () => {
-            registerPush();
+        document.getElementById('bc-send').addEventListener('click', async () => {
+            await registerPush();
             const title = (document.getElementById('bc-title').value || '').trim();
             const body = (document.getElementById('bc-body').value || '').trim();
-            fetch('/broadcast', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title, body })
-            });
+            try {
+                const res = await fetch('/broadcast', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ title, body })
+                });
+                if (res.ok) {
+                    alert('Notification sent');
+                } else {
+                    alert('Broadcast failed: ' + (await res.text()));
+                }
+            } catch (err) {
+                alert('Broadcast failed: ' + (err instanceof Error ? err.message : String(err)));
+            }
         });
 
         if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- make the broadcast send click handler async and wait for registerPush
- await the broadcast request and surface success or failure to the user
- wrap the broadcast call in try/catch to alert runtime or network issues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c83d0c7488832a97dc491715ebbf92