### PR TITLE
Add explicit index.html route

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,12 @@ def index():
     return send_from_directory('.', 'index.html')  # Adjust path as needed
 
 
+@app.route('/index.html')
+def index_html():
+    """Serve index.html when the file path is requested explicitly."""
+    return send_from_directory('.', 'index.html')
+
+
 @app.route('/vapid-public-key', methods=['GET'])
 def get_vapid_public_key():
     """Expose the configured VAPID public key for the frontend."""


### PR DESCRIPTION
## Summary
- add an explicit `/index.html` Flask route so service workers requesting that path receive the correct page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84741fc14832a8527f85488399cdc