### PR TITLE
Integrate APNs push handling and externalize DB config

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ gunicorn
 flask==3.1.0
 psycopg2==2.9.10
 pywebpush==1.9.4
-six==1.16.0
+httpx==0.27.2
+PyJWT==2.9.0
 six==1.16.0


### PR DESCRIPTION
## Summary
- add APNs-specific push delivery that signs short-lived JWTs and retires invalid subscriptions
- load PostgreSQL connection settings from environment variables
- add httpx and PyJWT dependencies while removing the duplicate six entry

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68c951ce8914832aa07dd1f34b0eabc3